### PR TITLE
Ensure class custom-control used for payment methods

### DIFF
--- a/includes/templates/bootstrap/templates/tpl_checkout_payment_default.php
+++ b/includes/templates/bootstrap/templates/tpl_checkout_payment_default.php
@@ -169,7 +169,7 @@
 <?php
   $radio_buttons = 0;
   for ($i=0, $n=sizeof($selection); $i<$n; $i++) {
-?><div id="paymentMethodsOption-card" class="card mb-3">
+?><div id="paymentMethodsOption-card" class="card mb-3 custom-control">
 <?php
     if (sizeof($selection) >= 1) {
         if (empty($selection[$i]['noradio'])) {


### PR DESCRIPTION
Otherwise the name is squashed on top of the radio button. 